### PR TITLE
fix: rename external::brew() -> external::brews() to match framework dispatch

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -15,11 +15,11 @@ p6df::modules::bash::deps() {
 ######################################################################
 #<
 #
-# Function: p6df::modules::bash::external::brew()
+# Function: p6df::modules::bash::external::brews()
 #
 #>
 ######################################################################
-p6df::modules::bash::external::brew() {
+p6df::modules::bash::external::brews() {
 
   p6df::core::homebrew::cli::brew::install bash
 


### PR DESCRIPTION
## Summary
- Rename `external::brew()` → `external::brews()` to match the plural form dispatched by `p6df-core/lib/module.zsh`

## Test plan
- [ ] Verify `p6df::core::module::brews` dispatch resolves correctly