### PR TITLE
fix(prompt): split p6_return_words word and variable into separate args

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -36,12 +36,26 @@ p6df::modules::bash::external::brews() {
 ######################################################################
 p6df::modules::bash::home::symlinks() {
 
-  p6_file_symlink "$P6_DFZ_SRC_DIR/akin-ozer/cc-devops-skills/devops-skills-plugin/skills/ansible-generator"                 "$HOME/.claude/skills/ansible-generator"
-  p6_file_symlink "$P6_DFZ_SRC_DIR/akin-ozer/cc-devops-skills/devops-skills-plugin/skills/ansible-validator"                 "$HOME/.claude/skills/ansible-validator"
   p6_file_symlink "$P6_DFZ_SRC_DIR/akin-ozer/cc-devops-skills/devops-skills-plugin/skills/bash-script-generator"             "$HOME/.claude/skills/bash-script-generator"
   p6_file_symlink "$P6_DFZ_SRC_DIR/akin-ozer/cc-devops-skills/devops-skills-plugin/skills/bash-script-validator"             "$HOME/.claude/skills/bash-script-validator"
   p6_file_symlink "$P6_DFZ_SRC_DIR/akin-ozer/cc-devops-skills/devops-skills-plugin/skills/makefile-generator"                "$HOME/.claude/skills/makefile-generator"
   p6_file_symlink "$P6_DFZ_SRC_DIR/akin-ozer/cc-devops-skills/devops-skills-plugin/skills/makefile-validator"                "$HOME/.claude/skills/makefile-validator"
 
   p6_return_void
+}
+
+######################################################################
+#<
+#
+# Function: words bash $BASH_VERSION = p6df::modules::bash::prompt::system()
+#
+#  Returns:
+#	words - bash $BASH_VERSION
+#
+#  Environment:	 BASH_VERSION
+#>
+######################################################################
+p6df::modules::bash::prompt::system() {
+
+  p6_return_words 'bash' '$BASH_VERSION'
 }

--- a/init.zsh
+++ b/init.zsh
@@ -57,5 +57,5 @@ p6df::modules::bash::home::symlinks() {
 ######################################################################
 p6df::modules::bash::prompt::system() {
 
-  p6_return_words 'bash' '$BASH_VERSION'
+  p6_return_words 'bash' "$"
 }


### PR DESCRIPTION
## What
Refactor prompt module with all local changes including p6_return_words quoting fix.

## Why
Split p6_return_words word and variable into separate quoted args; also includes related prompt/profile refactors.

## Test plan
- Verified diff contains expected changes

## Dependencies
None