### PR TITLE
refactor(module): remove unused prompt system function

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -43,19 +43,3 @@ p6df::modules::bash::home::symlinks() {
 
   p6_return_void
 }
-
-######################################################################
-#<
-#
-# Function: words bash $BASH_VERSION = p6df::modules::bash::prompt::system()
-#
-#  Returns:
-#	words - bash $BASH_VERSION
-#
-#  Environment:	 BASH_VERSION
-#>
-######################################################################
-p6df::modules::bash::prompt::system() {
-
-  p6_return_words 'bash' "$"
-}


### PR DESCRIPTION
## What
Remove the dead-code function `p6df::modules::bash::prompt::system()` from `init.zsh`, which returned a placeholder `$` string with no actual value.

## Why
This function was an unused stub that returned a meaningless placeholder. Removing it reduces maintenance surface and avoids confusion.

## Test plan
- Reviewed diff manually
- No callers of this function exist in this module

## Dependencies
None