### PR TITLE
chore(init): reorder hooks per hook_api.md lifecycle order

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -1,11 +1,5 @@
 # shellcheck shell=bash
 ######################################################################
-#<
-#
-# Function: p6df::modules::bash::deps()
-#
-#>
-######################################################################
 p6df::modules::bash::deps() {
   ModuleDeps=(
     p6m7g8-dotfiles/p6common
@@ -13,11 +7,15 @@ p6df::modules::bash::deps() {
 }
 
 ######################################################################
-#<
-#
-# Function: p6df::modules::bash::external::brews()
-#
-#>
+p6df::modules::bash::home::symlinks() {
+
+  p6_file_symlink "$P6_DFZ_SRC_DIR/akin-ozer/cc-devops-skills/devops-skills-plugin/skills/bash-script-generator"             "$HOME/.claude/skills/bash-script-generator"
+  p6_file_symlink "$P6_DFZ_SRC_DIR/akin-ozer/cc-devops-skills/devops-skills-plugin/skills/bash-script-validator"             "$HOME/.claude/skills/bash-script-validator"
+  p6_file_symlink "$P6_DFZ_SRC_DIR/akin-ozer/cc-devops-skills/devops-skills-plugin/skills/makefile-generator"                "$HOME/.claude/skills/makefile-generator"
+  p6_file_symlink "$P6_DFZ_SRC_DIR/akin-ozer/cc-devops-skills/devops-skills-plugin/skills/makefile-validator"                "$HOME/.claude/skills/makefile-validator"
+
+  p6_return_void
+}
 ######################################################################
 p6df::modules::bash::external::brews() {
 
@@ -29,17 +27,19 @@ p6df::modules::bash::external::brews() {
 ######################################################################
 #<
 #
+# Function: p6df::modules::bash::deps()
+#
+#>
+######################################################################
+#<
+#
+# Function: p6df::modules::bash::external::brews()
+#
+#>
+######################################################################
+#<
+#
 # Function: p6df::modules::bash::home::symlinks()
 #
 #  Environment:	 HOME P6_DFZ_SRC_DIR
 #>
-######################################################################
-p6df::modules::bash::home::symlinks() {
-
-  p6_file_symlink "$P6_DFZ_SRC_DIR/akin-ozer/cc-devops-skills/devops-skills-plugin/skills/bash-script-generator"             "$HOME/.claude/skills/bash-script-generator"
-  p6_file_symlink "$P6_DFZ_SRC_DIR/akin-ozer/cc-devops-skills/devops-skills-plugin/skills/bash-script-validator"             "$HOME/.claude/skills/bash-script-validator"
-  p6_file_symlink "$P6_DFZ_SRC_DIR/akin-ozer/cc-devops-skills/devops-skills-plugin/skills/makefile-generator"                "$HOME/.claude/skills/makefile-generator"
-  p6_file_symlink "$P6_DFZ_SRC_DIR/akin-ozer/cc-devops-skills/devops-skills-plugin/skills/makefile-validator"                "$HOME/.claude/skills/makefile-validator"
-
-  p6_return_void
-}

--- a/init.zsh
+++ b/init.zsh
@@ -1,11 +1,24 @@
 # shellcheck shell=bash
 ######################################################################
+#<
+#
+# Function: p6df::modules::bash::deps()
+#
+#>
+######################################################################
 p6df::modules::bash::deps() {
   ModuleDeps=(
     p6m7g8-dotfiles/p6common
   )
 }
 
+######################################################################
+#<
+#
+# Function: p6df::modules::bash::home::symlinks()
+#
+#  Environment:	 HOME P6_DFZ_SRC_DIR
+#>
 ######################################################################
 p6df::modules::bash::home::symlinks() {
 
@@ -17,6 +30,12 @@ p6df::modules::bash::home::symlinks() {
   p6_return_void
 }
 ######################################################################
+#<
+#
+# Function: p6df::modules::bash::external::brews()
+#
+#>
+######################################################################
 p6df::modules::bash::external::brews() {
 
   p6df::core::homebrew::cli::brew::install bash
@@ -24,22 +43,3 @@ p6df::modules::bash::external::brews() {
   p6_return_void
 }
 
-######################################################################
-#<
-#
-# Function: p6df::modules::bash::deps()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::bash::external::brews()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::bash::home::symlinks()
-#
-#  Environment:	 HOME P6_DFZ_SRC_DIR
-#>


### PR DESCRIPTION
## What
Reorder hook functions in `init.zsh` to match the canonical lifecycle order defined in `p6df-core/doc/hook_api.md`.

**Lifecycle:** `deps → init → env::init → path::init → cdpath::init → fpath::init → completions::init → aliases::init → langmgr::init → prompt::init`

**Install-time:** `home::symlinks → external::brews → langs → mcp → vscodes → vscodes::config`

**Profile:** `profile::on → profile::off → profile::mod → prompt::mod::bottom`

## Why
Hook functions were defined in inconsistent order across modules. Enforcing the canonical order makes the files easier to audit and ensures the documented execution sequence is visually obvious.

## Test plan
- [ ] Verified hook order with automated check (all pass)
- [ ] No functional changes — only block reordering

## Dependencies
None